### PR TITLE
Added curl-dev to apk update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /tmp/build && \
     apk add glibc-2.23-r3.apk && \
 
     # Install PIP
-    apk add --no-cache --update curl jq python-dev && \
+    apk add --no-cache --update curl curl-dev jq python-dev && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,8 @@ test:
   override:
     - docker run --entrypoint /bin/sh unifio/ci -c "gem list | grep covalence"
     - docker run --entrypoint /bin/sh unifio/ci -c "aws --version"
-    - docker run --entrypoint /bin/sh unifio/ci -c "packer version"
-    - docker run --entrypoint /bin/sh unifio/ci -c "terraform version"
+    - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "packer version"
+    - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
 
 deployment:
   hub:


### PR DESCRIPTION
- The latest curl was failing due to a dependency on the curl-dev package. Was reporting:
curl: (48) An unknown option was passed in to libcurl
- Added curl-dev issue no longer seen.
- Added CHECKPOINT_DISABLE to circle.yml to avoid latest version check with hashicorp server.