### PR TITLE
Added script to copy node binaries from unifio/ci:node-2.0.0 tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkr_files/**
 tf_files/**
+node_files/**
+node_files.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ RUN mkdir -p /tmp/build && \
 
 COPY pkr_files/packer* /usr/local/bin/
 COPY tf_files/terraform* /usr/local/bin/
+ADD node_files.tar.gz /

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Unif.io CI Dockerfile
 [![CircleCI](https://circleci.com/gh/unifio/dockerfile-ci.svg?style=svg)](https://circleci.com/gh/unifio/dockerfile-ci)
+

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,11 @@ machine:
     MAJOR_VERSION_TAG: 1
     PACKER_VERSION_TAG: latest
     TERRAFORM_VERISON_TAG: latest
+    CI_DEST_DIR: 'node_files'
+    CI_CONTAINER_NAME: 'unifio-ci'
+    CI_IMAGE_NAME: 'unifio/ci:node-2.0.0'
+    CI_SCRIPT_DEBUG: 1
+
   services:
     - docker
 
@@ -11,10 +16,11 @@ dependencies:
     - "~/docker"
   override:
     - docker info
-    - docker run --name packer unifio/packer:${PACKER_VERSION_TAG} version 
+    - docker run --name packer unifio/packer:${PACKER_VERSION_TAG} version
     - docker run --name terraform unifio/terraform:${TERRAFORM_VERSION_TAG} version
     - docker cp packer:/usr/local/bin/ pkr_files
     - docker cp terraform:/usr/local/bin/ tf_files
+    - mkdir -p ${CI_DEST_DIR} && ./copybins.sh
     - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
     - docker build -t unifio/ci .
     - mkdir -p ~/docker; docker save unifio/ci > ~/docker/image.tar

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,8 @@ test:
     - docker run --entrypoint /bin/sh unifio/ci -c "aws --version"
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "packer version"
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
+    - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
+    - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
 
 deployment:
   hub:

--- a/copybins.sh
+++ b/copybins.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+platform=''
+tarOpt=''
+tarArgs=''
+unamestr=$(uname)
+ciScriptDebug=${CI_SCRIPT_DEBUG:-""}
+#unamestr="Linux"
+if [[ "$unamestr" == 'Linux' ]]; then
+  platform='linux'
+  tarOpt=''
+  tarArgs="--wildcards --exclude=*zipinfo*"
+elif [[ "$unamestr" == 'Darwin' || "$unamestr" == 'FreeBSD' ]]; then
+  platform='freebsd'
+  tarOpt=''
+  tarArgs=''
+fi
+if [[ $ciScriptDebug ]];then
+  theArgs="-v $theArgs"
+fi
+
+read -r -d '' fileList << EOM
+${tarOpt} /usr/bin/unzip        \
+${tarOpt} /usr/include/node     \
+${tarOpt} /usr/lib/node_modules \
+${tarOpt} /usr/share/doc        \
+${tarOpt} /usr/share/systemtap  \
+${tarOpt} /usr/bin/node         \
+${tarOpt} /usr/bin/zip
+EOM
+# Set Default values or check for environment variable override
+destDir=${CI_DEST_DIR:-"node_files"}
+containerName=${CI_CONTAINER_NAME:-"unifio-ci"}
+imageName=${CI_IMAGE_NAME:-"unifio/ci:node-2.0.0"}
+containerSuffix=${CI_CONTAINER_SUFFIX:-""}
+binaryFile=${CI_BINARY_FILE:-"node"}
+# Run the container, name it, and get binary version number.
+docker run --entrypoint "${binaryFile}" --name "${containerName}" \
+        "${imageName}" --version 2>/dev/null
+# now verify that the container ran and echo its ID for reference
+matchingStarted=$(docker ps -lqa --filter="name=${containerName}" \
+              --format="{{.Names}},{{.ID}},{{.Image}},{{.Command}}")
+echo "Last container ran matching ${matchingStarted}"
+
+if [[ $matchingStarted ]]; then
+  docker cp "${containerName}":/ - | (cd "${destDir}" && tar -xp $tarArgs $fileList)
+  tar czvf ./"${destDir}".tar.gz -C "${destDir}"/ usr/
+  if tar tvzf ./"${destDir}".tar.gz | grep -q "\/bin\/${binaryFile}\$"; then
+    echo "$binaryFile found in tarball ready for copy to container"
+  fi
+fi


### PR DESCRIPTION
- Kept the script generic so we could build off of it with other things we may need to build and add to the monolith container. 
- Should probably add terraform and packer to the script to make it easier when building locally so you don't have to copy and paste commands from the circle yaml. 
- Directory structure was annoying because it wasn't all in one location so required doing something crafty with tar and matching on full paths for each element allowing the archive to be expanded using ADD. 
