### PR TITLE
Adding tf and pkr to the copybins.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Unif.io CI Dockerfile
 [![CircleCI](https://circleci.com/gh/unifio/dockerfile-ci.svg?style=svg)](https://circleci.com/gh/unifio/dockerfile-ci)
 
+To build with the latest packer/terraform/node binaries in the CI container first initialize all the binaries:
+
+```
+PACKER_VERSION_TAG=latest TERRAFORM_VERSION_TAG=latest CI_DEST_DIR=node_files CI_CONTAINER_NAME=unifio-ci CI_NODE_IMAGE_NAME='unifio/ci:node-2.0.0' CI_SCRIPT_DEBUG=1 TF_IMAGE='unifio/terraform' PKR_IMAGE='unifio/packer' ./copybins.sh
+```
+
+Then build:
+
+```
+docker build -t unifio/ci .
+```
+
+Then test container has all the latest binaries.
+
+```
+docker run --entrypoint /bin/sh unifio/ci -c "gem list | grep covalence"
+docker run --entrypoint /bin/sh unifio/ci -c "aws --version"
+docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "packer version"
+docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
+docker run --entrypoint /bin/sh unifio/ci -c "node --version"
+docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
+```

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,14 @@
 machine:
   environment:
-    MAJOR_VERSION_TAG: 1
+    MAJOR_VERSION_TAG: 2
     PACKER_VERSION_TAG: latest
-    TERRAFORM_VERISON_TAG: latest
+    TERRAFORM_VERSION_TAG: latest
     CI_DEST_DIR: 'node_files'
     CI_CONTAINER_NAME: 'unifio-ci'
-    CI_IMAGE_NAME: 'unifio/ci:node-2.0.0'
+    CI_NODE_IMAGE_NAME: 'unifio/ci:node-2.0.0'
     CI_SCRIPT_DEBUG: 1
+    TF_IMAGE: 'unifio/terraform'
+    PKR_IMAGE: 'unifio/packer'
 
   services:
     - docker
@@ -16,11 +18,7 @@ dependencies:
     - "~/docker"
   override:
     - docker info
-    - docker run --name packer unifio/packer:${PACKER_VERSION_TAG} version
-    - docker run --name terraform unifio/terraform:${TERRAFORM_VERSION_TAG} version
-    - docker cp packer:/usr/local/bin/ pkr_files
-    - docker cp terraform:/usr/local/bin/ tf_files
-    - mkdir -p ${CI_DEST_DIR} && ./copybins.sh
+    - ./copybins.sh
     - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
     - docker build -t unifio/ci .
     - mkdir -p ~/docker; docker save unifio/ci > ~/docker/image.tar


### PR DESCRIPTION
- Added the terraform and packer binary copy process to the copybins.sh so that while developing on this locally you can run ./copybins.sh and it will create the needed directories and tag the containers as needed like circle does during a build.
- Added directions in readme for compiling the latest binaries and building/testing the CI container.