### PR TITLE
Add Atlas Promote Tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ RUN mkdir -p /tmp/build && \
 
 COPY pkr_files/packer* /usr/local/bin/
 COPY tf_files/terraform* /usr/local/bin/
+COPY other_bins/* /usr/local/bin/
 ADD node_files.tar.gz /

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
     - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
     - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
-    - if [[ -z "$CIRCLE_TOKEN" ]]; then docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"; fi
+    - if [[ -n "$CIRCLE_TOKEN" ]]; then docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"; fi
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,7 @@ test:
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
     - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
     - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
+    - [[ CIRCLE_TOKEN != "" }} && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
     - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
     - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
-    - [[ -z "$CIRCLE_TOKEN" ]] && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
+    - if [[ -z "$CIRCLE_TOKEN" ]]; then docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"; fi
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
     - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
     - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
-    - [[ CIRCLE_TOKEN != "" }} && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
+    - [[ CIRCLE_TOKEN != "" ]] && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
 
 deployment:
   hub:

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     - docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh unifio/ci -c "terraform version"
     - docker run --entrypoint /bin/sh unifio/ci -c "node --version"
     - docker run --entrypoint /bin/sh unifio/ci -c "npm --version"
-    - [[ CIRCLE_TOKEN != "" ]] && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
+    - [[ -z "$CIRCLE_TOKEN" ]] && docker run --entrypoint /bin/sh unifio/ci -c "promote-atlas-artifact --version"
 
 deployment:
   hub:

--- a/copybins.sh
+++ b/copybins.sh
@@ -8,6 +8,9 @@ tf_version=${TERRAFORM_VERSION_TAG:-""}
 pkr_version=${PACKER_VERSION_TAG:-""}
 tf_image=${TF_IMAGE:-'unifio/terraform'}
 pkr_image=${PKR_IMAGE:-'unifio/packer'}
+artifact_tool=${ARTIFACT_TOOL:-'unifio/promote-atlas-artifact'}
+artifact_tool_version=${ARTIFACT_TOOL_VERSION:-'latest'}
+circle_token=${CIRCLE_TOKEN:-""}
 
 if [[ "$unamestr" == 'Linux' ]]; then
   platform='linux'
@@ -80,4 +83,14 @@ if [[ $pkr_version && $pkr_image ]]; then
     echo "Copying binaries.."
     docker cp packer:/usr/local/bin/ pkr_files
   fi
+fi
+
+# Include the promote artifact tool into container
+if [[ $circle_token != "" ]]; then
+    curl https://circleci.com/api/v1.1/project/github/${artifact_tool}/${artifact_tool_version}/artifacts?circle-token=$circle_token | grep -o 'https://[^"]*' | \
+    while read bin; do
+        bin_name=`basename $bin`
+        curl ${bin}?circle-token=$circle_token > /usr/local/bin/${bin_name}
+        chmod 755 /usr/local/bin/${bin_name}
+    done
 fi

--- a/copybins.sh
+++ b/copybins.sh
@@ -86,7 +86,7 @@ if [[ $pkr_version && $pkr_image ]]; then
 fi
 
 # Include the promote artifact tool into container
-if [[ $circle_token != "" ]]; then
+if [[ -z "$circle_token" ]]; then
     curl https://circleci.com/api/v1.1/project/github/${artifact_tool}/${artifact_tool_version}/artifacts?circle-token=$circle_token | grep -o 'https://[^"]*' | \
     while read bin; do
         bin_name=`basename $bin`

--- a/copybins.sh
+++ b/copybins.sh
@@ -86,7 +86,7 @@ if [[ $pkr_version && $pkr_image ]]; then
 fi
 
 # Include the promote artifact tool into container
-if [[ -z "$circle_token" ]]; then
+if [[ -n "$circle_token" ]]; then
     curl https://circleci.com/api/v1.1/project/github/${artifact_tool}/${artifact_tool_version}/artifacts?circle-token=$circle_token | grep -o 'https://[^"]*' | \
     while read bin; do
         bin_name=`basename $bin`

--- a/copybins.sh
+++ b/copybins.sh
@@ -86,11 +86,12 @@ if [[ $pkr_version && $pkr_image ]]; then
 fi
 
 # Include the promote artifact tool into container
+mkdir other_bins
 if [[ -n "$circle_token" ]]; then
     curl https://circleci.com/api/v1.1/project/github/${artifact_tool}/${artifact_tool_version}/artifacts?circle-token=$circle_token | grep -o 'https://[^"]*' | \
     while read bin; do
         bin_name=`basename $bin`
-        curl ${bin}?circle-token=$circle_token > /usr/local/bin/${bin_name}
-        chmod 755 /usr/local/bin/${bin_name}
+        curl ${bin}?circle-token=$circle_token > other_bins/${bin_name}
+        chmod 755 other_bins/${bin_name}
     done
 fi


### PR DESCRIPTION
If the build contains the env variable for circle ci token, use that to download latest version of the tool and include it in the ci container.