### PR TITLE
Updating CI Tool chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,21 @@
 common: &common
   working_directory: ~/dockerfile-ci
   docker:
-    - image: alpine:3.6
+    - image: alpine:3.7
   environment:
-    ALPINE_VERSION: '3.6'
+    ALPINE_VERSION: '3.7'
     CI_REGISTRY: 'unifio/ci'
     CI_MAJOR_VERSION: '3'
     COVALENCE_REGISTRY: 'unifio/covalence'
     COVALENCE_VERSION: '0.7.6'
     DUMBINIT_VERSION: '1.2.1'
     GOSU_VERSION: '1.10'
-    NODE_VERSION: '8.9.1'
+    NODE_VERSION: '8.9.4'
     PACKER_REGISTRY: 'unifio/packer'
     PACKER_VERSION: '1.1.3'
     RUBY_VERSION: '2.4'
     TERRAFORM_REGISTRY: 'unifio/terraform'
-    TERRAFORM_VERSION: '0.10.8'
+    TERRAFORM_VERSION: '0.11.3'
 
 version: 2
 jobs:
@@ -134,9 +134,9 @@ jobs:
             sleep 10
             docker start uat
             docker cp tools/terraform/uat/. uat:/data
-            docker exec uat sh -c 'terraform init'
-            docker exec uat sh -c 'terraform plan'
-            docker exec uat sh -c 'terraform apply'
+            docker exec uat sh -c 'terraform init -input=false'
+            docker exec uat sh -c 'terraform plan -input=false'
+            docker exec uat sh -c 'terraform apply -input=false -auto-approve'
             docker exec uat sh -c 'terraform destroy -force'
       - run:
           name: Save Docker image layer cache

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Unif.io, Inc. <support@unif.io>"
 
 ARG packer_version
 ENV PACKER_VERSION $packer_version
+ENV HASHI_KEY_URL https://keybase.io/hashicorp/key.asc
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
@@ -23,8 +24,7 @@ RUN set -ex; \
   mkdir -p /tmp/build && \
   cd /tmp/build && \
   \
-  keyserver=$(getent ahostsv4 keys.gnupg.net | grep STREAM | head -n 1 | cut -d ' ' -f 1); \
-  gpg --keyserver $keyserver --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+  wget -O - $HASHI_KEY_URL | gpg --import; \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig" && \

--- a/tools/terraform/Dockerfile
+++ b/tools/terraform/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="Unif.io, Inc. <support@unif.io>"
 
 ARG terraform_version
 ENV TERRAFORM_VERSION $terraform_version
+ENV HASHI_KEY_URL https://keybase.io/hashicorp/key.asc
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
@@ -25,8 +26,7 @@ RUN set -ex; \
   mkdir -p /tmp/build && \
   cd /tmp/build && \
   \
-  keyserver=$(getent ahostsv4 keys.gnupg.net | grep STREAM | head -n 1 | cut -d ' ' -f 1); \
-  gpg --keyserver $keyserver --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+  wget -O - $HASHI_KEY_URL | gpg --import; \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig" && \


### PR DESCRIPTION
#### Updating CI Tool chain
* Updating CI container hashicorp tools

#### Add handling for TF 0.11 confirmation workflow
* Added `-input=false` and `-auto-approve` to terraform commands during build to handle latest changes in [0.11.* Streamlined CLI Workflow](https://www.hashicorp.com/blog/hashicorp-terraform-0-11#streamlined-cli-workflow)
* [Automated workflow practices](https://www.terraform.io/guides/running-terraform-in-automation.html) applied.

#### Download/import PGP key from keybase for verify
* Downloading PGP key directly without using unstable keys.gnupg.net to avoid frequent timeouts during build.