### PR TITLE
Covalence version bump to 0.8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,16 @@ common: &common
     CI_REGISTRY: 'unifio/ci'
     CI_MAJOR_VERSION: '3'
     COVALENCE_REGISTRY: 'unifio/covalence'
-    COVALENCE_VERSION: '0.8.1'
+    COVALENCE_VERSION: '0.8.3'
     DUMBINIT_VERSION: '1.2.1'
     GOSU_VERSION: '1.10'
     NODE_VERSION: '8.9.4'
     PACKER_REGISTRY: 'unifio/packer'
     PACKER_VERSION: '1.1.3'
     RUBY_VERSION: '2.5.1'
-    SOPS_VERSION: '3.0.5'
+    SOPS_VERSION: '3.1.1'
     TERRAFORM_REGISTRY: 'unifio/terraform'
-    TERRAFORM_VERSION: '0.11.7'
+    TERRAFORM_VERSION: '0.11.8'
 
 version: 2
 jobs:

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -106,7 +106,7 @@ RUN set -ex; \
   cd /tmp/build && \
   \
   # Install glibc
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
   wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
   apk add glibc-2.23-r3.apk && \
   \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -126,7 +126,7 @@ RUN set -ex; \
   cd /tmp/build && \
   \
   # Install glibc
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
   wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
   apk add glibc-2.23-r3.apk && \
   \

--- a/tools/covalence/uat/terraform/vpc/vpc.tf
+++ b/tools/covalence/uat/terraform/vpc/vpc.tf
@@ -20,7 +20,7 @@ provider "aws" {
 
 ## Configures base VPC
 module "vpc_base" {
-  source = "github.com/unifio/terraform-aws-vpc?ref=v0.3.2//base"
+  source = "github.com/unifio/terraform-aws-vpc?ref=v0.3.8//base"
 
   stack_item_label    = "${var.stack_item_label}"
   stack_item_fullname = "${var.stack_item_fullname}"

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex; \
   grep packer_${PACKER_VERSION}_linux_amd64.zip packer_${PACKER_VERSION}_SHA256SUMS | sha256sum -c && \
   unzip -d /usr/local/bin packer_${PACKER_VERSION}_linux_amd64.zip && \
   \
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
   wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
   apk add --no-cache --update glibc-2.23-r3.apk && \
   \

--- a/tools/terraform/Dockerfile
+++ b/tools/terraform/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex; \
   grep terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS | sha256sum -c && \
   unzip -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
   \
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
   wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
   apk add --no-cache --update glibc-2.23-r3.apk && \
   \


### PR DESCRIPTION
* Updating to covalence version 0.8.3 to address issues with [sops version output handling](https://github.com/unifio/covalence/issues/72)