### PR TITLE
Adding zip, updating Tools and Alpine OS to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,22 @@
 common: &common
   working_directory: ~/dockerfile-ci
   docker:
-    - image: alpine:3.7
+    - image: alpine:3.8
   environment:
-    ALPINE_VERSION: '3.7'
+    ALPINE_VERSION: '3.8'
     CI_REGISTRY: 'unifio/ci'
     CI_MAJOR_VERSION: '3'
     COVALENCE_REGISTRY: 'unifio/covalence'
     COVALENCE_VERSION: '0.8.3'
-    DUMBINIT_VERSION: '1.2.1'
-    GOSU_VERSION: '1.10'
-    NODE_VERSION: '8.9.4'
+    DUMBINIT_VERSION: '1.2.2'
+    GOSU_VERSION: '1.11'
+    NODE_VERSION: '8.11'
     PACKER_REGISTRY: 'unifio/packer'
     PACKER_VERSION: '1.1.3'
-    RUBY_VERSION: '2.5.1'
-    SOPS_VERSION: '3.1.1'
+    RUBY_VERSION: '2.5.3'
+    SOPS_VERSION: '3.2.0'
     TERRAFORM_REGISTRY: 'unifio/terraform'
-    TERRAFORM_VERSION: '0.11.8'
+    TERRAFORM_VERSION: '0.11.11'
 
 version: 2
 jobs:
@@ -261,7 +261,7 @@ jobs:
             python get-pip.py
             pip install --upgrade \
               docker-compose
-            gem install bundler --no-ri --no-rdoc
+            gem install bundler --no-document
       - attach_workspace:
           at: /workspace
       - restore_cache:
@@ -367,7 +367,7 @@ jobs:
             python get-pip.py
             pip install --upgrade \
               docker-compose
-            gem install bundler --no-ri --no-rdoc
+            gem install bundler --no-document
       - attach_workspace:
           at: /workspace
       - restore_cache:

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -98,6 +98,7 @@ RUN set -ex; \
     ruby-dev \
     tar \
     unzip \
+    zip \
     wget \
   '; \
   apk add --no-cache --update $fetchDeps && \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -116,6 +116,7 @@ RUN set -ex; \
     ruby-json \
     tar \
     unzip \
+    zip \
     wget \
     yaml-dev \
     zlib-dev \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -66,7 +66,7 @@ RUN set -ex; \
   cd /tmp/build && \
   \
   # Ruby Gems
-  gem install bundler --no-ri --no-rdoc && \
+  gem install bundler --no-document  && \
   bundle install --path=/opt/gems --jobs=4 --retry=3
 
 FROM node:${node_version}-alpine
@@ -139,7 +139,7 @@ RUN set -ex; \
     docker-compose && \
   \
   # Install gem packages
-  gem install bundler --no-ri --no-rdoc && \
+  gem install bundler --no-document  && \
   bundle check --gemfile=/opt/Gemfile --path=/opt/gems || bundle install --gemfile=/opt/Gemfile --path=/opt/gems --jobs=4 --retry=3 && \
   \
   # Cleanup

--- a/tools/covalence/Dockerfile
+++ b/tools/covalence/Dockerfile
@@ -44,9 +44,9 @@ RUN set -ex; \
   cp bin/dumb-init /usr/local/bin && \
 
   # Covalence
-  gem install covalence -v $COVALENCE_VERSION --no-ri --no-rdoc && \
-  gem install dotenv serverspec --no-ri --no-rdoc && \
-  gem install rspec ci_reporter_rspec --no-ri --no-rdoc && \
+  gem install covalence -v $COVALENCE_VERSION --no-document  && \
+  gem install dotenv serverspec --no-document  && \
+  gem install rspec ci_reporter_rspec --no-document  && \
 
   # Cleanup
   cd /tmp && \

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -65,7 +65,7 @@ RUN set -ex; \
   \
   chmod +x packer-post-processor-vagrant-s3 packer-provisioner-serverspec && \
   mv packer-post-processor-vagrant-s3 packer-provisioner-serverspec /usr/local/bin && \
-  gem install io-console bundler rake rspec serverspec --no-ri --no-rdoc && \
+  gem install io-console bundler rake rspec serverspec --no-document  && \
   \
   cd / && \
   rm -rf /tmp/build


### PR DESCRIPTION
* Updated ruby to 2.5.3
  * Required removing --no-ri --no-rdoc deprecated options for --no-document to avoid errors. 
* Updated SOPS to latest 3.2.0 release. 
* Updated Terraform to 0.11.11
* Updated gosu to 1.11
* Updated node to 8.11
* Rev'd CI major version to 4 since the OS was updated.
* Added zip to ci container to facilitate the compression and generation of certs via openssl. zip compression is required for consumption by AWS EMR services.