### PR TITLE
Upgrade Terraform / Update alpine build container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ common: &common
     RUBY_VERSION: '2.5.3'
     SOPS_VERSION: '3.2.0'
     TERRAFORM_REGISTRY: 'unifio/terraform'
-    TERRAFORM_VERSION: '0.11.13'
+    TERRAFORM_VERSION: '0.11.14'
 
 version: 2
 jobs:
@@ -29,12 +29,20 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
+            apk update && apk add --no-cache \
               curl \
+              ca-certificates \
+              curl-dev \
               docker \
-              python-dev
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py
+              build-base \
+              python3-dev \
+              gcc \
+              libffi-dev
+            python3 -m ensurepip && \
+            rm -r /usr/lib/python*/ensurepip && \
+            pip3 install --upgrade pip setuptools && \
+            if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
             pip install --upgrade \
               docker-compose
       - restore_cache:
@@ -102,12 +110,20 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
+            apk update && apk add --no-cache \
               curl \
+              ca-certificates \
+              curl-dev \
               docker \
-              python-dev
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py
+              build-base \
+              python3-dev \
+              gcc \
+              libffi-dev
+            python3 -m ensurepip && \
+            rm -r /usr/lib/python*/ensurepip && \
+            pip3 install --upgrade pip setuptools && \
+            if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
             pip install --upgrade \
               docker-compose
       - restore_cache:
@@ -172,10 +188,19 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
+            apk update && apk add --no-cache \
               curl \
               docker \
-              python-dev
+              build-base \
+              python3-dev \
+              gcc \
+              libffi-dev\
+              openssl-dev
+            python3 -m ensurepip && \
+            rm -r /usr/lib/python*/ensurepip && \
+            pip3 install --upgrade pip setuptools && \
+            if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
             curl -O https://bootstrap.pypa.io/get-pip.py
             python get-pip.py
             pip install --upgrade \
@@ -240,25 +265,30 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
-              bash \
-              build-base \
-              ca-certificates \
+            apk update && apk add --no-cache \
               curl \
+              ca-certificates \
               curl-dev \
               docker \
+              build-base \
+              python3-dev \
+              gcc \
+              libffi-dev \
               libxml2-dev \
               libxslt-dev \
-              openssl \
-              python-dev \
               ruby \
               ruby-bundler \
               ruby-dev \
               ruby-io-console \
               ruby-json \
-              tar
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py
+              tar \
+              bash
+
+            python3 -m ensurepip && \
+            rm -r /usr/lib/python*/ensurepip && \
+            pip3 install --upgrade pip setuptools && \
+            if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
             pip install --upgrade \
               docker-compose
             gem install bundler --no-document
@@ -346,25 +376,30 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
-              bash \
-              build-base \
-              ca-certificates \
+            apk update && apk add --no-cache \
               curl \
+              ca-certificates \
               curl-dev \
               docker \
+              build-base \
+              python3-dev \
+              gcc \
+              libffi-dev \
               libxml2-dev \
               libxslt-dev \
-              openssl \
-              python-dev \
               ruby \
               ruby-bundler \
               ruby-dev \
               ruby-io-console \
               ruby-json \
-              tar
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py
+              tar \
+              bash
+
+            python3 -m ensurepip && \
+            rm -r /usr/lib/python*/ensurepip && \
+            pip3 install --upgrade pip setuptools && \
+            if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip; fi && \
+            if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
             pip install --upgrade \
               docker-compose
             gem install bundler --no-document

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -35,8 +35,8 @@ RUN set -ex; \
   wget -O /tmp/build/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
   wget -O /tmp/build/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
   \
-  keyserver=$(getent ahostsv4 ha.pool.sks-keyservers.net | grep STREAM | head -n 1 | cut -d ' ' -f 1); \
-  gpg --keyserver $keyserver --receive-keys $GOSU_KEY; \
+  ( gpg --keyserver ipv4.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" \
+  || gpg --keyserver ha.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" ); \
   gpg --batch --verify gosu.asc gosu; \
   chmod +x gosu; \
   \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -44,8 +44,8 @@ RUN set -ex; \
   wget -O /tmp/build/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
   wget -O /tmp/build/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
   \
-  keyserver=$(getent ahostsv4 ha.pool.sks-keyservers.net | grep STREAM | head -n 1 | cut -d ' ' -f 1); \
-  gpg --keyserver $keyserver --receive-keys $GOSU_KEY; \
+  ( gpg --keyserver ipv4.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" \
+  || gpg --keyserver ha.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" ); \
   gpg --batch --verify gosu.asc gosu; \
   chmod +x gosu; \
   \

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -60,9 +60,11 @@ RUN set -ex; \
   mkdir -p /tmp/build && \
   cd /tmp/build && \
   \
-  wget -q "https://circle-artifacts.com/gh/unifio/packer-post-processor-vagrant-s3/22/artifacts/0/home/ubuntu/.go_workspace/bin/packer-post-processor-vagrant-s3" && \
-  wget -q "https://circle-artifacts.com/gh/unifio/packer-provisioner-serverspec/26/artifacts/0/home/ubuntu/.go_workspace/bin/packer-provisioner-serverspec" && \
+  wget -q "https://github.com/unifio/packer-post-processor-vagrant-s3/releases/download/v.0.0.1/packer-post-processor-vagrant-s3_0.0.1_linux_amd64.zip" && \
+  wget -q "https://github.com/unifio/packer-provisioner-serverspec/releases/download/v0.0.1/packer-provisioner-serverspec_0.0.1_linux_amd64.zip" && \
   \
+  unzip -o packer-post-processor-vagrant-s3_0.0.1_linux_amd64.zip && \
+  unzip -o packer-provisioner-serverspec_0.0.1_linux_amd64.zip && \
   chmod +x packer-post-processor-vagrant-s3 packer-provisioner-serverspec && \
   mv packer-post-processor-vagrant-s3 packer-provisioner-serverspec /usr/local/bin && \
   gem install io-console bundler rake rspec serverspec --no-document  && \


### PR DESCRIPTION
* Updated Terraform to version 0.11.14
* Updated build dependencies since it was failing as a result of alpine apk dep changes.
* Updated to python 3 in build container when installing docker-compose to address deprecation warning.
* Added reordered the deps in each build phase to allow easy migration to an updated circleci config that leverages a global definition and orb for this pattern.
* Verified that this configuration will also build on alpine 3.9 leaving on 3.8 for now however.