### PR TITLE
Packer serverspec Update/ Terraform 0.12.10 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.3.1'
       TERRAFORM_REGISTRY: 'unifio/terraform'
-      TERRAFORM_VERSION: '0.12.9'
+      TERRAFORM_VERSION: '0.12.10'
       PREFIXOUT_VERSION: '0.1.0'
       BUNDLER_VERSION: '1.17.3'
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.3.1'
       TERRAFORM_REGISTRY: 'unifio/terraform'
-      TERRAFORM_VERSION: '0.12.9'
+      TERRAFORM_VERSION: '0.12.10'
 ```
 
 To build locally with the latest binaries in the CI container first initialize all the binaries:
@@ -31,5 +31,5 @@ TERRAFORM_VERSION=0.10.8 docker-compose terraform
 Then build:
 
 ```
-COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.4.4 TERRAFORM_VERSION=0.12.9 docker-compose build
+COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.4.4 TERRAFORM_VERSION=0.12.10 docker-compose build
 ```

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -63,10 +63,10 @@ RUN set -ex; \
   cd /tmp/build && \
   \
   wget -q "https://github.com/lmars/packer-post-processor-vagrant-s3/releases/download/1.4.0/packer-post-processor-vagrant-s3-1.4.0-linux-amd64.zip" && \
-  wget -q "https://github.com/unifio/packer-provisioner-serverspec/releases/download/v0.1.0/packer-provisioner-serverspec_0.1.0_Linux_x86_64.tar.gz" && \
+  wget -q "https://github.com/unifio/packer-provisioner-serverspec/releases/download/v0.1.1/packer-provisioner-serverspec_0.1.1_linux_amd64.tar.gz" && \
   \
   unzip -o packer-post-processor-vagrant-s3-1.4.0-linux-amd64.zip && \
-  tar xvfz packer-provisioner-serverspec_0.1.0_Linux_x86_64.tar.gz && \
+  tar xvfz packer-provisioner-serverspec_0.1.1_linux_amd64.tar.gz && \
   chmod +x packer-post-processor-vagrant-s3 packer-provisioner-serverspec && \
   mv packer-post-processor-vagrant-s3 packer-provisioner-serverspec /usr/local/bin && \
   gem install io-console bundler rake rspec serverspec --no-document  && \


### PR DESCRIPTION
* Updated packer provisioner to use the latest binary that is using the latest packer 1.4.4 include on build.
* Updated Terraform to 0.12.10