### PR TITLE
Upgrade packer to 1.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       GOSU_VERSION: '1.11'
       NODE_VERSION: '10.16.1'
       PACKER_REGISTRY: 'unifio/packer'
-      PACKER_VERSION: '1.4.5'
+      PACKER_VERSION: '1.5.0'
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.3.1'
       TERRAFORM_REGISTRY: 'unifio/terraform'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
       GOSU_VERSION: '1.11'
       NODE_VERSION: '10.16.1'
       PACKER_REGISTRY: 'unifio/packer'
-      PACKER_VERSION: '1.4.5'
+      PACKER_VERSION: '1.5.0'
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.3.1'
       TERRAFORM_REGISTRY: 'unifio/terraform'
@@ -24,12 +24,12 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
 To build locally with the latest binaries in the CI container first initialize all the binaries:
 
 ```
-PACKER_VERSION=1.4.5  docker-compose packer
+PACKER_VERSION=1.5.0  docker-compose packer
 TERRAFORM_VERSION=0.10.8 docker-compose terraform
 ./copybins.sh
 ```
 Then build:
 
 ```
-COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.4.5 TERRAFORM_VERSION=0.12.18 docker-compose build
+COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.5.0 TERRAFORM_VERSION=0.12.18 docker-compose build
 ```


### PR DESCRIPTION
* Upgraded packer to 1.5.0
* [See Backwards Incompatibilities](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#backwards-incompatibilities) for details on breaking changes.

### BACKWARDS INCOMPATIBILITIES:
* builder/amazon: Complete deprecation of clean_ami_name template func
    [GH-8320] [GH-8193]
* core: Changes have been made to both the Prepare() method signature on the
    builder interface and on the Provision() method signature on the
    provisioner interface. [GH-7866]
* provisioner/ansible-local: The "galaxycommand" option has been renamed to
    "galaxy_command". A fixer has been written for this, which can be invoked
    with `packer fix`. [GH-8411]
