### PR TITLE
Adding build phase for vagrant-s3 post processor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       GOSU_VERSION: '1.11'
       NODE_VERSION: '10.16.1'
       PACKER_REGISTRY: 'unifio/packer'
-      PACKER_VERSION: '1.4.5'
+      PACKER_VERSION: '1.5.6'
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.5.0'
       TERRAFORM_REGISTRY: 'unifio/terraform'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
       GOSU_VERSION: '1.11'
       NODE_VERSION: '10.16.1'
       PACKER_REGISTRY: 'unifio/packer'
-      PACKER_VERSION: '1.4.5'
+      PACKER_VERSION: '1.5.6'
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.5.0'
       TERRAFORM_REGISTRY: 'unifio/terraform'
@@ -24,12 +24,12 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
 To build locally with the latest binaries in the CI container first initialize all the binaries:
 
 ```
-PACKER_VERSION=1.4.5  docker-compose packer
+PACKER_VERSION=1.5.6  docker-compose packer
 TERRAFORM_VERSION=0.10.8 docker-compose terraform
 ./copybins.sh
 ```
 Then build:
 
 ```
-COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.4.5 TERRAFORM_VERSION=0.12.25 docker-compose build
+COVALENCE_VERSION=0.9.7 PACKER_VERSION=1.5.6 TERRAFORM_VERSION=0.12.25 docker-compose build
 ```

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -1,4 +1,10 @@
 ARG alpine_version
+# Golang Build stage for vagrants3 plugin
+FROM golang:alpine AS golang-build
+RUN apk --no-cache add build-base git bzr mercurial gcc && \
+GO111MODULE=on go get github.com/lmars/packer-post-processor-vagrant-s3 && \
+file /go/bin/packer-post-processor-vagrant-s3
+
 FROM alpine:${alpine_version}
 LABEL maintainer="Unif.io, Inc. <support@unif.io>"
 
@@ -62,13 +68,11 @@ RUN set -ex; \
   mkdir -p /tmp/build && \
   cd /tmp/build && \
   \
-  wget -q "https://github.com/lmars/packer-post-processor-vagrant-s3/releases/download/1.4.0/packer-post-processor-vagrant-s3-1.4.0-linux-amd64.zip" && \
-  wget -q "https://github.com/unifio/packer-provisioner-serverspec/releases/download/v0.1.1/packer-provisioner-serverspec_0.1.1_linux_amd64.tar.gz" && \
+  wget -q "https://github.com/unifio/packer-provisioner-serverspec/releases/download/v0.2.0/packer-provisioner-serverspec_0.2.0_linux_amd64.tar.gz" && \
   \
-  unzip -o packer-post-processor-vagrant-s3-1.4.0-linux-amd64.zip && \
-  tar xvfz packer-provisioner-serverspec_0.1.1_linux_amd64.tar.gz && \
-  chmod +x packer-post-processor-vagrant-s3 packer-provisioner-serverspec && \
-  mv packer-post-processor-vagrant-s3 packer-provisioner-serverspec /usr/local/bin && \
+  tar xvfz packer-provisioner-serverspec_0.2.0_linux_amd64.tar.gz && \
+  chmod +x packer-provisioner-serverspec && \
+  mv packer-provisioner-serverspec /usr/local/bin && \
   gem install io-console bundler rake rspec serverspec --no-document  && \
   \
   cd / && \
@@ -89,7 +93,7 @@ RUN set -ex; \
   cd / && \
   rm -rf /tmp/build && \
   docker -v
-
+COPY --from=golang-build /go/bin/packer-post-processor-vagrant-s3 /usr/local/bin
 COPY entrypoint.sh /usr/local/bin/
 
 VOLUME ["/data"]


### PR DESCRIPTION
## issue 67
* Added stage to build packer-post-processor-vagrant-s3 from the master branch lmars/packer-post-processor-vagrant-s3.
* Updated packer to 1.5.6
* Updated serverspec to 0.2.0 which has the 1.5.4 packer support.