### PR TITLE
Updating terraform 0.12.31 / Fixing some build errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.6.0'
       TERRAFORM_REGISTRY: 'unifio/terraform'
-      TERRAFORM_VERSION: '0.12.29'
+      TERRAFORM_VERSION: '0.12.31'
       BUNDLER_VERSION: '1.17.3'
 
 jobs:

--- a/Dockerfile-infra
+++ b/Dockerfile-infra
@@ -35,8 +35,8 @@ RUN set -ex; \
   wget -O /tmp/build/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
   wget -O /tmp/build/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
   \
-  ( gpg --keyserver ipv4.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" \
-  || gpg --keyserver ha.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" ); \
+  ( gpg --keyserver keys.openpgp.org --receive-keys "$GOSU_KEY" \
+  || gpg --keyserver hkp://keyserver.ubuntu.com:80 --receive-keys "$GOSU_KEY" ); \
   gpg --batch --verify gosu.asc gosu; \
   chmod +x gosu; \
   \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -49,8 +49,8 @@ RUN set -ex; \
   wget -O /tmp/build/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
   wget -O /tmp/build/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
   \
-  ( gpg --keyserver ipv4.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" \
-  || gpg --keyserver ha.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" ); \
+  ( gpg --keyserver pgp.mit.edu --receive-keys "$GOSU_KEY" \
+  || gpg --keyserver keys.openpgp.org --receive-keys "$GOSU_KEY" ); \
   gpg --batch --verify gosu.asc gosu; \
   chmod +x gosu; \
   \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Update the global environment variables from the [.circleci/config.xml](./.circl
       RUBY_VERSION: '2.5.5'
       SOPS_VERSION: '3.6.0'
       TERRAFORM_REGISTRY: 'unifio/terraform'
-      TERRAFORM_VERSION: '0.12.29'
+      TERRAFORM_VERSION: '0.12.31'
 ```
 
 To build locally with the latest binaries in the CI container first initialize all the binaries:
@@ -31,5 +31,5 @@ TERRAFORM_VERSION=0.10.8 docker-compose build terraform
 Then build:
 
 ```
-COVALENCE_VERSION=0.9.9 PACKER_VERSION=1.6.4 TERRAFORM_VERSION=0.12.29 docker-compose build
+COVALENCE_VERSION=0.9.9 PACKER_VERSION=1.6.4 TERRAFORM_VERSION=0.12.31 docker-compose build
 ```

--- a/tools/packer/Dockerfile
+++ b/tools/packer/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex; \
   tar xvfz packer-provisioner-serverspec_${PACKER_SERVERSPEC_VERSION}_linux_amd64.tar.gz && \
   chmod +x packer-provisioner-serverspec && \
   mv packer-provisioner-serverspec /usr/local/bin && \
-  gem install io-console bundler rake rspec serverspec --no-document  && \
+  gem install io-console:0.5.9 bundler rake rspec serverspec --no-document  && \
   \
   cd / && \
   rm -rf /tmp/build

--- a/tools/terraform/Dockerfile
+++ b/tools/terraform/Dockerfile
@@ -4,30 +4,20 @@ LABEL maintainer="Unif.io, Inc. <support@unif.io>"
 
 ARG terraform_version
 ENV TERRAFORM_VERSION $terraform_version
-ENV HASHI_KEY_URL https://keybase.io/hashicorp/key.asc
+ENV HASHI_KEY_URL https://rpm.releases.hashicorp.com/gpg
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
 ENV DOCKER_BASE_VERSION=0.0.4
 
 RUN set -ex; \
-  \
-  fetchDeps=' \
-    ca-certificates \
-    gnupg \
-    git \
-    openssl \
-    openssh \
-    mercurial \
-    unzip \
-    wget \
-  '; \
-  apk add --no-cache --update $fetchDeps && \
-  \
+  apk add --no-cache --update build-base ca-certificates curl gnupg openssl && \
+      ruby-dev unzip wget tini su-exec libffi-dev && \
   mkdir -p /tmp/build && \
   cd /tmp/build && \
   \
   wget -O - $HASHI_KEY_URL | gpg --import; \
+  wget -O - https://keybase.io/hashicorp/pgp_keys.asc | gpg --import; \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS" && \
   wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig" && \


### PR DESCRIPTION
* Updated terraform to 0.12.31
* Specifying io-console version in packer build on gem install to avoid an issue with updated version and support for ruby version.
* Removing sks keyservers and using updated ones for gpg keys